### PR TITLE
fix: handle `example` keyword

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -3,7 +3,7 @@ import addFormats from 'ajv-formats'
 import standaloneCode from 'ajv/dist/standalone/index.js'
 import set from 'just-safe-set'
 
-const ajv = new AJV({ code: { source: true } })
+const ajv = new AJV({ code: { source: true }, keywords: [ 'example' ] })
 addFormats(ajv) // for OpenAPI schemas
 
 const encode = string => string.toString().replaceAll('~', '~0').replaceAll('/', '~1')


### PR DESCRIPTION
This change allows us to run ajv-openapi-compile against the [ipfs-pinning-service.yaml][1] which includes `example` properties.

By adding `example` as a keyword, we avoid blowing up when passing the schema to ajv.

There is no doubt a more complete set of keywords that could be added here, but it's not clear to me how to figure out the diff between the set of openapi keywords and the ajv json schema keywords.

[1]: https://github.com/ipfs/pinning-services-api-spec/blob/main/ipfs-pinning-service.yaml

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>